### PR TITLE
#125 restore user progress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4671,6 +4671,11 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
+    "html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
+    },
     "http-browserify": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "can-stache-route-helpers": "^1.1.1",
     "cuid": "^2.1.8",
     "escape-string-regexp": "^4.0.0",
+    "html-entities": "^2.3.2",
     "jquery": "^3.5.1",
     "lodash": "^4.17.15",
     "moment": "^2.25.3",

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -6,6 +6,7 @@ import Answers from '~/models/answers-from-viewer'
 import constants from '~/models/constants'
 import cString from '~/utils/string'
 import cDate from '~/utils/date'
+import { decode } from 'html-entities'
 
 const mapANX2Var = {
   unknown: constants.vtUnknown,
@@ -153,7 +154,11 @@ export default {
 
       switch (varANXType) {
         case 'textvalue':
-          guide.varSet(varName, $(this).find('TextValue').html())
+          let answerValue = $(this).find('TextValue').html()
+          if (varName === 'visitedpages') {
+            answerValue = decode(answerValue)
+          }
+          guide.varSet(varName, answerValue)
           break
 
         case 'numvalue':

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -112,6 +112,10 @@ let setVariable = function (variable, pages) {
 }
 
 export default {
+  decodeHTMLEntities (answerXML, options) {
+    return options ? decode(answerXML, options) : decode(answerXML)
+  },
+
   parseANX (answers, pages) {
     var xml = constants.HotDocsANXHeader_UTF8_str // jshint ignore:line
 
@@ -156,7 +160,7 @@ export default {
         case 'textvalue':
           let answerValue = $(this).find('TextValue').html()
           if (varName === 'visitedpages') {
-            answerValue = decode(answerValue)
+            answerValue = this.decodeHTMLEntities(answerValue)
           }
           guide.varSet(varName, answerValue)
           break

--- a/utils/tests/parser-test.js
+++ b/utils/tests/parser-test.js
@@ -61,8 +61,8 @@ describe('Parser', function () {
   })
 
   it('decodes html-entities to HTML tags', function () {
-    let encodedText = '&lt;p&gt;Text of my first question goes here.&lt;/p&gt;\n'
-    let decodedAnswers = '<p>Text of my first question goes here.</p>\n'
+    let encodedText = '&lt;p&gt;Text of my first question goes here, &amp; &quot;Some quotes&quot;.&lt;/p&gt;\n'
+    let decodedAnswers = '<p>Text of my first question goes here, & "Some quotes".</p>\n'
 
     assert.equal(Parser.decodeHTMLEntities(encodedText), decodedAnswers, 'Should convert html-entities to HTML tags')
   })

--- a/utils/tests/parser-test.js
+++ b/utils/tests/parser-test.js
@@ -64,6 +64,6 @@ describe('Parser', function () {
     let encodedText = '&lt;p&gt;Text of my first question goes here.&lt;/p&gt;\n'
     let decodedAnswers = '<p>Text of my first question goes here.</p>\n'
 
-    assert.equal(decode(encodedText), decodedAnswers, 'TF answer not of type boolean')
+    assert.equal(Parser.decodeHTMLEntities(encodedText), decodedAnswers, 'Should convert html-entities to HTML tags')
   })
 })

--- a/utils/tests/parser-test.js
+++ b/utils/tests/parser-test.js
@@ -5,6 +5,7 @@ import partialXML from '~/models/fixtures/partial.anx!text' // eslint-disable-li
 import interviewJSON from '~/models/fixtures/interview.json'
 import answersJSON from '~/models/fixtures/inclusive_answers.json'
 import answersXML from '~/models/fixtures/inclusive_answers.xml!text' // eslint-disable-line
+import { decode } from 'html-entities'
 
 // These correspond to an interview that has repeating variables
 import answersWithRepeating from './fixtures/answers-with-repeating-values.json'
@@ -57,5 +58,12 @@ describe('Parser', function () {
     assert.equal(parsedAnswers['client last name te'].values[21], 'Dang', 'Text values')
     assert.equal(parsedAnswers['dob da'].values[21], '02/02/1980', 'Date values')
     assert.equal(parsedAnswers['chocolate tf'].values[21], true, 'TF values')
+  })
+
+  it('decodes html-entities to HTML tags', function () {
+    let encodedText = '&lt;p&gt;Text of my first question goes here.&lt;/p&gt;\n'
+    let decodedAnswers = '<p>Text of my first question goes here.</p>\n'
+
+    assert.equal(decode(encodedText), decodedAnswers, 'TF answer not of type boolean')
   })
 })


### PR DESCRIPTION
Added npm package `html-entities`, to decode entities to HTML tags for the `My Progress` navigation dropdown and the advance nav page name display. 