### PR TITLE
template header footer duplicate names

### DIFF
--- a/elements/a2j-header-footer/a2j-header-footer.stache
+++ b/elements/a2j-header-footer/a2j-header-footer.stache
@@ -4,7 +4,12 @@
 {{#not(editActive)}}
   {{#if(containsWords)}}
     <div class="preview" on:click="setEditActive(true)">
-      {{{ userContent }}}
+      <a2j-rich-text
+      userContent:from="userContent"
+      showOptionsPane:from="showOptionsPane"
+      wrapWithContainer:from="wrapWithContainer"
+      fontProperties:from="fontProperties"
+      setUserContent:from="setUserContent" />
     </div>
   {{/if}}
 {{else}}


### PR DESCRIPTION
Rich text header footer variable selections were showing double entries. Fixed that here.