### PR TITLE
Communicate “page breaks” via more than just styles #51

### DIFF
--- a/elements/a2j-page-break/a2j-page-break-test.js
+++ b/elements/a2j-page-break/a2j-page-break-test.js
@@ -1,0 +1,33 @@
+import $ from 'jquery'
+import F from 'funcunit'
+import { assert } from 'chai'
+import stache from 'can-stache'
+
+import 'steal-mocha'
+import '~/author-styles.less'
+import './a2j-page-break'
+
+describe('a2j-page-break', function () {
+  describe('Component', function () {
+    beforeEach(function () {
+      const frag = stache('<div class="bootstrap-styles"><a2j-page-break /></div>')
+      $('#test-area').html(frag())
+    })
+
+    afterEach(function () {
+      $('#test-area').empty()
+    })
+
+    it('is not visible on screen', function (done) {
+      const paragraph = F('a2j-page-break > p')
+
+      F(function () {
+        assert.strictEqual(paragraph.text(), 'Page break', 'should have the correct text')
+        assert.strictEqual(paragraph.height(), 1, 'should be clipped to 1px height')
+        assert.strictEqual(paragraph.width(), 1, 'should be clipped to 1px width')
+      })
+
+      F(done)
+    })
+  })
+})

--- a/elements/a2j-page-break/a2j-page-break.html
+++ b/elements/a2j-page-break/a2j-page-break.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<title>A2J-Page-Break Tests</title>
+<div id="mocha"></div>
+<div id="test-area"></div>
+<script src="../../node_modules/steal/steal.js" mocha="bdd" main="~/elements/a2j-page-break/a2j-page-break-test"></script>

--- a/elements/a2j-page-break/a2j-page-break.stache
+++ b/elements/a2j-page-break/a2j-page-break.stache
@@ -30,4 +30,6 @@
       </form>
     </element-options-pane>
   {{/if}}
+{{else}}
+  <p class="sr-only">Page break</p>
 {{/if}}

--- a/elements/a2j-page-break/demo.html
+++ b/elements/a2j-page-break/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>&lt;a2j-page-break&gt;</title>
+  </head>
+  <body class="bootstrap-styles">
+    <script id="template" type="text/stache" can-autorender>
+      <can-import from="~/author-styles.less" />
+      <can-import from="~/elements/a2j-page-break/" />
+      <a2j-page-break />
+    </script>
+    <script src="../../node_modules/steal/steal.js" main="can-view-autorender/"></script>
+  </body>
+</html>

--- a/elements/tests/tests.js
+++ b/elements/tests/tests.js
@@ -1,5 +1,6 @@
 import '~/elements/a2j-conditional/a2j-conditional-test'
 import '~/elements/a2j-header-footer/a2j-header-footer-test'
+import '~/elements/a2j-page-break/a2j-page-break-test'
 import '~/elements/a2j-repeat-loop/a2j-repeat-loop-test'
 import '~/elements/a2j-template/a2j-template-test'
 import '~/elements/a2j-template-ssr/a2j-template-ssr-test'


### PR DESCRIPTION
Previously, the page break element was not perceivable to screen readers because it rendered no text.

Now, some text will be in the DOM for screen readers to read, while the visual representation of the page break has not changed.

Closes https://github.com/CCALI/a2jdeps/issues/51