### PR TITLE
Remove the use of list elements for non-lists

### DIFF
--- a/elements/a2j-template/a2j-template.js
+++ b/elements/a2j-template/a2j-template.js
@@ -13,7 +13,7 @@ export default Component.extend('A2JTemplateComponent', {
       evt.stopPropagation()
     },
 
-    'li dragstart': function (el, evt) {
+    'section dragstart': function (el, evt) {
       evt.stopPropagation()
       let $el = $(el)
       let dt = evt.dataTransfer
@@ -23,7 +23,7 @@ export default Component.extend('A2JTemplateComponent', {
       $(this.element).find('element-options-pane').hide()
     },
 
-    'li dragenter': function (el, evt) {
+    'section dragenter': function (el, evt) {
       evt.stopPropagation()
       let $el = $(el)
       let dropIndex = this.viewModel.attr('dropItemIndex')
@@ -36,7 +36,7 @@ export default Component.extend('A2JTemplateComponent', {
       }
     },
 
-    'li dragover': function ($el, evt) {
+    'section dragover': function ($el, evt) {
       evt.preventDefault()
 
       let dt = evt.dataTransfer
@@ -46,7 +46,7 @@ export default Component.extend('A2JTemplateComponent', {
     // this event won't be dispatched if the source node is moved during the
     // drag, causing the placeholder to stay visible after the elemet has been
     // dropped.
-    'li dragend': function () {
+    'section dragend': function () {
       this.viewModel.removeDragPlaceholderFlag()
 
       this.viewModel.attr({
@@ -55,7 +55,7 @@ export default Component.extend('A2JTemplateComponent', {
       })
     },
 
-    'li drop': function (el, evt) {
+    'section drop': function (el, evt) {
       evt.stopPropagation()
       this.viewModel.removeDragPlaceholderFlag()
 

--- a/elements/a2j-template/a2j-template.less
+++ b/elements/a2j-template/a2j-template.less
@@ -2,16 +2,8 @@
 
 a2j-template {
   display: block;
-
-  & > ul {
-    padding: 0;
-    list-style: none;
-    padding-bottom: 40px;
-  }
-
-  a2j-template & > ul {
-    padding: 0;
-  }
+  margin: 1em 0;
+  padding-bottom: 40px;
 
   .drag-placeholder {
     border: 1px dashed darken(@gray-lighter, 20%);

--- a/elements/a2j-template/a2j-template.stache
+++ b/elements/a2j-template/a2j-template.stache
@@ -6,9 +6,9 @@
 <can-import from="~/elements/a2j-section-title/" />
 <can-import from="~/elements/a2j-template/a2j-template.less" />
 
-<ul>
+<div>
   {{#for (childNode of rootNode.children) }}
-    <li
+    <section
       draggable="true"
       class="node-wrapper{{#if(childNode.isBeingDragged)}} drag-placeholder{{/if}}">
 
@@ -138,6 +138,6 @@
           toggleEditActiveNode:from="toggleEditActiveNode"
         />
       {{/eq}}
-    </li>
+    </section>
   {{/for}}
-</ul>
+</div>

--- a/elements/a2j-template/demo.html
+++ b/elements/a2j-template/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>&lt;a2j-template&gt;</title>
+</head>
+
+<body>
+  <div class="bootstrap-styles">
+    <div class="row clearfix" style="margin-top: 20px;">
+      <div class="col-md-12 app"></div>
+    </div>
+  </div>
+
+  <script>window.less = { async: true };</script>
+
+  <script src="../../../../node_modules/steal/steal.js" main="@empty">
+    require('elements/a2j-template/');
+
+    const $ = require('jquery');
+    const stache = require('can-stache/');
+    const A2JTemplate = require('~/models/a2j-template').default;
+    const templateFixture = require('~/models/fixtures-author/templates/guide1261-template2115').default;
+
+    function makeA2JTemplate({ rootNode }) {
+      const docTree = A2JTemplate.makeDocumentTree(rootNode)
+      const template = new A2JTemplate()
+      template.attr('rootNode', docTree)
+      return template
+    }
+
+    const template = '<a2j-template editEnabled:from="true" template:from="template" />';
+    const frag = stache(template);
+
+    $('.app').append(frag({
+      template: makeA2JTemplate(templateFixture)
+    }));
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
This changes `<a2j-template>` to use `<section>` elements instead of `<li>` elements.

Unfortunately I was not able to add tests for this change. I wanted to use FuncUnit’s [drag](https://funcunit.com/docs/FuncUnit.prototype.drag.html) method for testing the drag & drop functionality, but I believe it might expect to be used when dragging an element into another element, whereas this component reorders elements in the same parent. It might be possible to add tests for this in the future with more investigation.

Closes https://github.com/CCALI/a2jdeps/issues/52