### PR TITLE
add textindent plugin to ckeditor

### DIFF
--- a/elements/a2j-repeat-loop/a2j-repeat-loop.js
+++ b/elements/a2j-repeat-loop/a2j-repeat-loop.js
@@ -107,7 +107,7 @@ export default Component.extend({
         // check if we have access to the element while dragging is going on
         if ($textarea.get(0)) {
           let editor = window.CKEDITOR.replace($textarea.get(0), {
-            extraPlugins: 'a2j-variable,a2j-guid',
+            extraPlugins: 'a2j-variable,a2j-guid,textindent',
             extraAllowedContent: {
               'a2j-variable': {
                 attributes: ['name']

--- a/elements/a2j-rich-text/a2j-rich-text.js
+++ b/elements/a2j-rich-text/a2j-rich-text.js
@@ -181,7 +181,7 @@ export default Component.extend({
           let $textarea = $el.find('textarea')
 
           let editor = window.CKEDITOR.replace($textarea.get(0), {
-            extraPlugins: 'a2j-variable,a2j-guid',
+            extraPlugins: 'a2j-variable,a2j-guid,textindent',
             extraAllowedContent: {
               'a2j-variable': {
                 attributes: ['name']


### PR DESCRIPTION
This adds the textindent plugin to both rich-text and repeat-loop elements, allowing just first line indents on new paragraphs. Adds a toolbar button as well as triggered by the `tab` key by default.