### PR TITLE
Remove extra space around resolved variable values

### DIFF
--- a/elements/a2j-variable/a2j-variable.less
+++ b/elements/a2j-variable/a2j-variable.less
@@ -11,12 +11,18 @@ a2j-variable {
     background-color: #D7ECF5;
     vertical-align: middle;
 
-
     &.unanswered {
       visibility: hidden;
     }
   }
-  // this handles extra space around resolved a2j-variable names
+
+    // this removes extra space around a2j-variable names in the editor
+    span.var-name { 
+      margin-right: -0.25em;
+      margin-left: -0.25em;
+    }
+
+  // this removes extra space around resolved a2j-variable names in documents
     span.var-val { 
       margin-right: -0.25em;
       margin-left: -0.25em;

--- a/elements/a2j-variable/a2j-variable.less
+++ b/elements/a2j-variable/a2j-variable.less
@@ -11,8 +11,14 @@ a2j-variable {
     background-color: #D7ECF5;
     vertical-align: middle;
 
+
     &.unanswered {
       visibility: hidden;
     }
   }
+  // this handles extra space around resolved variable names
+    span.var-val { 
+      margin-right: -0.25em;
+      margin-left: -0.25em;
+    }
 }

--- a/elements/a2j-variable/a2j-variable.less
+++ b/elements/a2j-variable/a2j-variable.less
@@ -16,7 +16,7 @@ a2j-variable {
       visibility: hidden;
     }
   }
-  // this handles extra space around resolved variable names
+  // this handles extra space around resolved a2j-variable names
     span.var-val { 
       margin-right: -0.25em;
       margin-left: -0.25em;


### PR DESCRIPTION
This fixes an issue where resolved variable values were adding an extra space inline:
`Hello  Mike  , how are you`
and a very noticeable extra space at the end of a sentence with punctuation:
`Hello, my name is Mike .`

@JessicaFrank should QA this against older text templates and various fonts, font sizes and styling (italic, bold, etc) just to make sure there's no weird edge cases.

Closes CCALI/a2jdat#117